### PR TITLE
feat: Support Custom Serializer for Values

### DIFF
--- a/lib/sorbet-schema.rb
+++ b/lib/sorbet-schema.rb
@@ -21,6 +21,8 @@ loader.setup
 # but contains extensions, so we need to manually require it.
 require_relative "sorbet-schema/hash_transformer"
 require_relative "sorbet-schema/serialize_value"
+require_relative "sorbet-schema/serialize_value/custom_serializer"
+require_relative "sorbet-schema/serialize_value/custom_serializer_registry"
 
 # We want to add a default `schema` method to structs
 # that will guarentee a schema can be created for use

--- a/lib/sorbet-schema/serialize_value.rb
+++ b/lib/sorbet-schema/serialize_value.rb
@@ -3,9 +3,18 @@
 class SerializeValue
   extend T::Sig
 
+  sig { params(custom_serializer: T.class_of(CustomSerializer)).void }
+  def self.register_custom_serializer(custom_serializer)
+    CustomSerializerRegistry.instance.register(custom_serializer)
+  end
+
   sig { params(value: T.untyped).returns(T.untyped) }
   def self.serialize(value)
-    if value.is_a?(Hash)
+    custom_serializer = CustomSerializerRegistry.instance.select_serializer_by(value:)
+
+    if custom_serializer
+      custom_serializer.new.serialize(value).payload_or(value)
+    elsif value.is_a?(Hash)
       HashTransformer.serialize_values(value)
     elsif value.is_a?(Array)
       value.map { |item| serialize(item) }

--- a/lib/sorbet-schema/serialize_value/custom_serializer.rb
+++ b/lib/sorbet-schema/serialize_value/custom_serializer.rb
@@ -1,0 +1,23 @@
+# typed: strict
+
+class SerializeValue
+  class CustomSerializer
+    extend T::Sig
+    extend T::Generic
+
+    abstract!
+
+    sig { abstract.returns(T::Types::Base) }
+    def type
+    end
+
+    sig { params(value: Typed::Value).returns(T::Boolean) }
+    def used_for_value?(value)
+      value.is_a?(type)
+    end
+
+    sig { abstract.params(value: Typed::Value).returns(Typed::Result[String, Typed::SerializationError]) }
+    def serialize(value)
+    end
+  end
+end

--- a/lib/sorbet-schema/serialize_value/custom_serializer.rb
+++ b/lib/sorbet-schema/serialize_value/custom_serializer.rb
@@ -7,7 +7,7 @@ class SerializeValue
 
     abstract!
 
-    sig { abstract.returns(T::Types::Base) }
+    sig { abstract.returns(T::Class[T.anything]) }
     def type
     end
 

--- a/lib/sorbet-schema/serialize_value/custom_serializer_registry.rb
+++ b/lib/sorbet-schema/serialize_value/custom_serializer_registry.rb
@@ -1,0 +1,33 @@
+# typed: strict
+
+require "singleton"
+
+class SerializeValue
+  class CustomSerializerRegistry
+    extend T::Sig
+
+    include Singleton
+
+    Registry = T.type_alias { T::Array[T.class_of(CustomSerializer)] }
+
+    sig { void }
+    def initialize
+      @available = T.let([], Registry)
+    end
+
+    sig { params(serializer: T.class_of(CustomSerializer)).void }
+    def register(serializer)
+      @available.prepend(serializer)
+    end
+
+    sig { void }
+    def reset!
+      @available = []
+    end
+
+    sig { params(value: Typed::Value).returns(T.nilable(T.class_of(CustomSerializer))) }
+    def select_serializer_by(value:)
+      @available.find { |serializer| serializer.new.used_for_value?(value) }
+    end
+  end
+end


### PR DESCRIPTION
I was playing around with some ways to implement value serialization overrides. There are inline-serializers for `Schemas,` but they are limited to the top level of a nested struct.

This approach takes cues from how custom Coercers are implemented in this project via a "registry" singleton (Another approach I considered was an "undo-coercer," which only transforms coerces types into strings, but that's essentially a serializer).

I'm not entirely happy with this, but perhaps it's a good starting point for discussion.